### PR TITLE
Implementação de Operadores

### DIFF
--- a/src/ast_nodes/nodes.py
+++ b/src/ast_nodes/nodes.py
@@ -19,3 +19,12 @@ class Block:
 
     def __repr__(self):
         return f"Block(statements={self.statements})"
+    
+class BinOp:
+    def __init__(self, left, op, right):
+        self.left = left
+        self.op = op
+        self.right = right
+
+    def __repr__(self):
+        return f"BinOp({self.left} {self.op.type.name} {self.right})"

--- a/src/lexer/lexer.py
+++ b/src/lexer/lexer.py
@@ -82,6 +82,9 @@ class Lexer:
             if self.current_char == "+":
                 self.advance()
                 return Token(TokenType.PLUS)
+            if self.current_char == "-":
+                self.advance()
+                return Token(TokenType.MINUS)
 
             raise Exception(f"Caractere inválido: {self.current_char}")
 

--- a/src/lexer/lexer.py
+++ b/src/lexer/lexer.py
@@ -85,6 +85,12 @@ class Lexer:
             if self.current_char == "-":
                 self.advance()
                 return Token(TokenType.MINUS)
+            if self.current_char == "*":
+                self.advance()
+                return Token(TokenType.MULT)
+            if self.current_char == "/":
+                self.advance()
+                return Token(TokenType.DIV)
 
             raise Exception(f"Caractere inválido: {self.current_char}")
 

--- a/src/lexer/lexer.py
+++ b/src/lexer/lexer.py
@@ -79,6 +79,10 @@ class Lexer:
                 self.advance()
                 return Token(TokenType.RBRACE)
 
+            if self.current_char == "+":
+                self.advance()
+                return Token(TokenType.PLUS)
+
             raise Exception(f"Caractere inválido: {self.current_char}")
 
         return Token(TokenType.EOF)

--- a/src/lexer/tokens.py
+++ b/src/lexer/tokens.py
@@ -18,6 +18,7 @@ class TokenType(Enum):
     EOF = auto()
 
     PLUS = auto()
+    MINUS = auto()
 
 
 class Token:

--- a/src/lexer/tokens.py
+++ b/src/lexer/tokens.py
@@ -17,6 +17,8 @@ class TokenType(Enum):
 
     EOF = auto()
 
+    PLUS = auto()
+
 
 class Token:
     def __init__(self, type, value=None):

--- a/src/lexer/tokens.py
+++ b/src/lexer/tokens.py
@@ -19,6 +19,8 @@ class TokenType(Enum):
 
     PLUS = auto()
     MINUS = auto()
+    MULT = auto()
+    DIV = auto()
 
 
 class Token:

--- a/src/main.py
+++ b/src/main.py
@@ -19,7 +19,8 @@ def debug_tokens(code):
 def main():
     code = """
     int main() {
-        int x = 10 + 20 - b;
+        int x = 10 + 5 * 2;
+        int y = 20 / 4 - 2;
         return x;
     }
     """

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -62,9 +62,12 @@ class Parser:
     def parse_expression(self):
         left = self.parse_term()
 
-        while self.current_token.type == TokenType.PLUS:
+        while self.current_token.type in (TokenType.PLUS, TokenType.MINUS):
             op = self.current_token
-            self.eat(TokenType.PLUS)
+            if op.type == TokenType.PLUS:
+                self.eat(TokenType.PLUS)
+            else:
+                self.eat(TokenType.MINUS)
             right = self.parse_term()
             left = BinOp(left, op, right)
 

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -1,5 +1,5 @@
 from lexer.tokens import TokenType
-from ast_nodes.nodes import VarDecl, Return, Block
+from ast_nodes.nodes import VarDecl, Return, Block, BinOp
 
 
 class Parser:
@@ -25,8 +25,7 @@ class Parser:
 
         if self.current_token.type == TokenType.ASSIGN:
             self.eat(TokenType.ASSIGN)
-            value = self.current_token.value
-            self.eat(TokenType.NUMBER)
+            value = self.parse_expression()
 
         self.eat(TokenType.SEMICOLON)
 
@@ -35,18 +34,7 @@ class Parser:
     def parse_return(self):
         self.eat(TokenType.RETURN)
 
-        value = None
-
-        if self.current_token.type == TokenType.NUMBER:
-            value = self.current_token.value
-            self.eat(TokenType.NUMBER)
-
-        elif self.current_token.type == TokenType.IDENTIFIER:
-            value = self.current_token.value
-            self.eat(TokenType.IDENTIFIER)
-
-        else:
-            raise Exception("Erro: return precisa de um valor válido")
+        value = self.parse_expression()
 
         self.eat(TokenType.SEMICOLON)
 
@@ -70,3 +58,28 @@ class Parser:
         self.eat(TokenType.RBRACE)
 
         return Block(statements)
+    
+    def parse_expression(self):
+        left = self.parse_term()
+
+        while self.current_token.type == TokenType.PLUS:
+            op = self.current_token
+            self.eat(TokenType.PLUS)
+            right = self.parse_term()
+            left = BinOp(left, op, right)
+
+        return left
+    
+    def parse_term(self):
+        token = self.current_token
+
+        if token.type == TokenType.NUMBER:
+            self.eat(TokenType.NUMBER)
+            return token.value
+
+        elif token.type == TokenType.IDENTIFIER:
+            self.eat(TokenType.IDENTIFIER)
+            return token.value
+
+        else:
+            raise Exception(f"Token inesperado: {token}")

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -73,6 +73,20 @@ class Parser:
         return left
     
     def parse_term(self):
+        left = self.parse_factor() 
+
+        while self.current_token.type in (TokenType.MULT, TokenType.DIV):
+            op = self.current_token
+            if op.type == TokenType.MULT:
+                self.eat(TokenType.MULT)
+            else:
+                self.eat(TokenType.DIV)
+            right = self.parse_factor()
+            left = BinOp(left, op, right)
+
+        return left
+    
+    def parse_factor(self):
         token = self.current_token
 
         if token.type == TokenType.NUMBER:

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -1,0 +1,29 @@
+from lexer.lexer import Lexer
+from lexer.tokens import TokenType
+
+def test_lexer_multiplication_division():
+
+    code = "* /"
+    lexer = Lexer(code)
+    
+    token_mult = lexer.get_next_token()
+    token_div = lexer.get_next_token()
+    
+    assert token_mult.type == TokenType.MULT
+    assert token_div.type == TokenType.DIV
+
+def test_lexer_expression_tokens():
+    
+    code = "int x = 10 * 2 / 5;"
+    lexer = Lexer(code)
+    
+    tokens = []
+    while True:
+        tok = lexer.get_next_token()
+        tokens.append(tok.type)
+        if tok.type == TokenType.EOF:
+            break
+            
+    assert TokenType.MULT in tokens
+    assert TokenType.DIV in tokens
+    assert TokenType.SEMICOLON in tokens

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,5 +1,6 @@
 from lexer.lexer import Lexer
 from parser.parser import Parser
+from lexer.tokens import TokenType
 
 
 def test_var_decl():
@@ -29,16 +30,50 @@ def test_return_identifier():
 
     assert result.value == "y"
 
-def test_parse_block(self):
+def test_parse_block():
         code = "{ int x = 5; return x; }"
         parser = Parser(Lexer(code))
         result = parser.parse_block()
 
-        self.assertEqual(len(result.statements), 2)
+        assert len(result.statements) == 2
 
-def test_parse_main_program(self):
+def test_parse_main_program():
         code = "int main() { return 0; }"
         parser = Parser(Lexer(code))
         result = parser.parse_program()
         
-        self.assertIsNotNone(result.body)
+        assert result.body is not None
+
+def test_precedencia_multiplicacao():
+    
+    code = "int x = 2 + 3 * 4;"
+    parser = Parser(Lexer(code))
+    result = parser.parse_declaration() 
+
+    expr = result.value
+    assert expr.op.type == TokenType.PLUS
+    assert expr.right.op.type == TokenType.MULT
+    assert expr.right.left == 3
+    assert expr.right.right == 4
+
+def test_precedencia_divisao_subtracao():
+    
+    code = "int y = 10 / 2 - 1;"
+    parser = Parser(Lexer(code))
+    result = parser.parse_declaration()
+
+    expr = result.value
+    assert expr.op.type == TokenType.MINUS
+    assert expr.left.op.type == TokenType.DIV
+
+def test_parenteses_prioridade():
+    
+    code = "int z = (2 + 3) * 4;"
+    parser = Parser(Lexer(code))
+    result = parser.parse_declaration()
+
+    expr = result.value
+   
+    assert expr.op.type == TokenType.MULT
+    
+    assert expr.left.op.type == TokenType.PLUS


### PR DESCRIPTION

## Descrição
Este PR implementa o suporte aos operadores aritméticos de **multiplicação (`*`)** e **divisão (`/`)** no compilador. A principal entrega é a implementação da lógica de **precedência de operadores**, garantindo que as operações de maior prioridade sejam resolvidas corretamente na Árvore de Sintaxe Abstrata (AST), seguindo o comportamento padrão da linguagem C.

## Funcionalidade

* **Análise Léxica:** Reconhecimento dos caracteres `*` e `/` e geração dos respetivos tokens `MULT` e `DIV`.

* **Análise Sintática:** Implementação de uma estrutura hierárquica no parser (`Expression -> Term -> Factor`) para respeitar a precedência matemática.

* **Suporte a Parênteses:** Implementação de chamadas recursivas no `parse_factor` que permitem o uso de `()` para forçar a prioridade de subexpressões.

* **Testes Automatizados:** Inclusão de uma suíte de 11 testes garantindo o funcionamento do léxico, da sintaxe e da correta montagem da árvore em expressões simples e complexas.

## Alterações Realizadas

### Código Fonte

* **`src/lexer/tokens.py`**: Adição dos tipos de token `MULT` e `DIV` ao enum `TokenType`.
* **`src/lexer/lexer.py`**: Atualização da lógica de reconhecimento de caracteres para retornar os tokens de multiplicação e divisão.
* **`src/parser/parser.py`**: 
    * Implementação do método `parse_term` para gerir `*` e `/`.
    * Atualização do método `parse_expression` para delegar a chamada ao `parse_term`.
    * Inclusão de lógica recursiva para tratar `LPAREN` e `RPAREN` dentro do `parse_factor`.

### Testes
* **`tests/test_lexer.py`**: Criação de testes para validar a geração de tokens de novos operadores.
* **`tests/test_parser.py`**: Criação de casos de teste para validar a precedência (ex: `10 + 5 * 2`) e o uso de parênteses.

## Observações

Para garantir que a precedência lógicafuncionasse, sem quebrar a lógica iniciada pela equipe, foram realizadas as seguintes trocas técnicas:

1.  **Refatoração do Parser (`parser.py`):** O método que anteriormente se chamava `parse_term` (que lidava com Números e Identificadores) foi renomeado para **`parse_factor`**. Isso foi essencial para criar uma nova camada intermediária (`parse_term`), permitindo que a multiplicação/divisão "ganhasse" da soma/subtração na hierarquia da árvore.

2.  **Ajuste nos Testes (Pytest):** Os testes anteriores seguiam o padrão `unittest` (usando `self` e `self.assertEqual`). Para permitir a execução via terminal no ambiente virtual do projeto, as funções foram refatoradas para utilizar o comando nativo **`assert`** do Python, removendo a dependência de classes e do parâmetro `self`.

3.  **Configuração de Ambiente:** A execução dos testes agora requer a definição do `PYTHONPATH=src` para garantir que os módulos internos sejam localizados corretamente pelo executor de testes.

4. [Commit de Error Test](https://github.com/Beatriz-ge/Compiladores-Grupo11/commit/2a1bbb08c89e8dfcf4c1da3d6cf34c17f6a3fb31#commitcomment-182784302)